### PR TITLE
head: add noindex tag to make bots take the hint

### DIFF
--- a/templates/head.html
+++ b/templates/head.html
@@ -3,6 +3,7 @@
         <meta charset="UTF-8">
         <meta name="description" content="Official website of the MirahezeBot Sopel IRC custom modules.">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="robots" content="noindex,nofollow">
         <link rel="canonical" href="{canonical}">
         <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;300" rel="stylesheet" type="text/css">
         <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Apparently sticking canonical urls everywhere don't work