### PR TITLE
Revert "Bump flake8 from 3.8.4 to 4.0.1"

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 pip-check-reqs==2.3.2
 setuptools==51.1.2
 pytest==6.2.5
-flake8==4.0.1
+flake8==3.8.4
 flake8-docstrings==1.6.0
 flake8-import-order==0.18.1
 flake8-unused-arguments==0.0.9


### PR DESCRIPTION
Reverts MirahezeBots/mirahezebots.org#45 another package prevents us from using the newest version